### PR TITLE
Implement multiplication and fix issues with left shifting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -37,7 +37,7 @@ AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortEnumsOnASingleLine: true
-AllowShortFunctionsOnASingleLine: All
+AllowShortFunctionsOnASingleLine: Empty
 AllowShortIfStatementsOnASingleLine: Never
 AllowShortLambdasOnASingleLine: All
 AllowShortLoopsOnASingleLine: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.26)
 project(my_uint192 LANGUAGES CXX VERSION 0.0.1)
 set(CMAKE_CXX_STANDARD 23)
-
+SET(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 Include(FetchContent)
 
 add_subdirectory(uint_192_lib)

--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -1,0 +1,56 @@
+# Finds the GMP C++ library
+
+# Designed to included in the CMAKE_MODULE_PATH and called using find_package
+# Inspired by https://dominikberner.ch/cmake-find-library/
+include(GNUInstallDirs)
+
+find_library(
+        GMP_SHARED_LIBRARY
+        GMP
+        NAMES libgmpxx.so
+        PATH_SUFFIXES lib lib64
+)
+
+find_library(
+        GMP_STATIC_LIBRARY
+        GMP
+        NAMES libgmpxx.a
+        PATH_SUFFIXES lib lib64
+)
+
+find_path(GMP_INCLUDE_DIR
+        GMP
+        NAMES GMP gmpxx.h
+        PATH_SUFFIXES include
+)
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(GMP DEFAULT_MSG
+        GMP_SHARED_LIBRARY
+        GMP_STATIC_LIBRARY
+        GMP_INCLUDE_DIR)
+
+mark_as_advanced(GMP_LIBRARY GMP_INCLUDE_DIR)
+
+if (GMP_FOUND AND NOT TARGET GMP::SHARED)
+    add_library(GMP::SHARED SHARED IMPORTED)
+    target_include_directories(GMP::SHARED INTERFACE ${GMP_INCLUDE_DIR})
+    target_link_libraries(GMP::SHARED INTERFACE ${GMP_SHARED_LIBRARY})
+    set_target_properties(
+            GMP::SHARED
+            PROPERTIES
+            IMPORTED_LOCATION ${GMP_SHARED_LIBRARY}
+    )
+endif ()
+
+if (GMP_FOUND AND NOT TARGET GMP::STATIC)
+    add_library(GMP::STATIC STATIC IMPORTED)
+    target_include_directories(GMP::STATIC INTERFACE ${GMP_INCLUDE_DIR})
+    target_link_libraries(GMP::STATIC INTERFACE ${GMP_STATIC_LIBRARY})
+    set_target_properties(
+            GMP::STATIC
+            PROPERTIES
+            IMPORTED_LOCATION ${GMP_STATIC_LIBRARY}
+    )
+endif ()

--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -2,6 +2,8 @@
 
 # Designed to included in the CMAKE_MODULE_PATH and called using find_package
 # Inspired by https://dominikberner.ch/cmake-find-library/
+# Tested on linux only
+
 include(GNUInstallDirs)
 
 find_library(
@@ -12,9 +14,22 @@ find_library(
 )
 
 find_library(
+        GMP_C_SHARED_LIBRARY
+        GMP
+        NAMES libgmp.so
+        PATH_SUFFIXES lib lib64
+)
+
+find_library(
         GMP_STATIC_LIBRARY
         GMP
         NAMES libgmpxx.a
+        PATH_SUFFIXES lib lib64
+)
+find_library(
+        GMP_C_STATIC_LIBRARY
+        GMP
+        NAMES libgmp.a
         PATH_SUFFIXES lib lib64
 )
 
@@ -28,7 +43,9 @@ include(FindPackageHandleStandardArgs)
 
 find_package_handle_standard_args(GMP DEFAULT_MSG
         GMP_SHARED_LIBRARY
+        GMP_C_SHARED_LIBRARY
         GMP_STATIC_LIBRARY
+        GMP_C_STATIC_LIBRARY
         GMP_INCLUDE_DIR)
 
 mark_as_advanced(GMP_LIBRARY GMP_INCLUDE_DIR)
@@ -36,7 +53,7 @@ mark_as_advanced(GMP_LIBRARY GMP_INCLUDE_DIR)
 if (GMP_FOUND AND NOT TARGET GMP::SHARED)
     add_library(GMP::SHARED SHARED IMPORTED)
     target_include_directories(GMP::SHARED INTERFACE ${GMP_INCLUDE_DIR})
-    target_link_libraries(GMP::SHARED INTERFACE ${GMP_SHARED_LIBRARY})
+    target_link_libraries(GMP::SHARED INTERFACE ${GMP_C_SHARED_LIBRARY} ${GMP_SHARED_LIBRARY})
     set_target_properties(
             GMP::SHARED
             PROPERTIES
@@ -47,7 +64,7 @@ endif ()
 if (GMP_FOUND AND NOT TARGET GMP::STATIC)
     add_library(GMP::STATIC STATIC IMPORTED)
     target_include_directories(GMP::STATIC INTERFACE ${GMP_INCLUDE_DIR})
-    target_link_libraries(GMP::STATIC INTERFACE ${GMP_STATIC_LIBRARY})
+    target_link_libraries(GMP::STATIC INTERFACE ${GMP_C_STATIC_LIBRARY} ${GMP_STATIC_LIBRARY})
     set_target_properties(
             GMP::STATIC
             PROPERTIES

--- a/uint_192_lib/src/uint_192.hpp
+++ b/uint_192_lib/src/uint_192.hpp
@@ -10,6 +10,18 @@
 namespace uint192_lib {
 struct uint_192 {
     std::array<std::uint64_t, 3> parts;
+
+    constexpr uint_192 &operator+=(const uint_192 &rhs) noexcept {
+        uint64_t carry_bit{0};
+
+        for (uint64_t i = 0; i < this->parts.size(); ++i) {
+            this->parts[i] += carry_bit;
+            this->parts[i] += rhs.parts[i];
+            carry_bit = this->parts[i] < rhs.parts[i];
+        }
+
+        return *this;
+    }
 };
 
 constexpr uint_192 operator+(const uint_192 &lhs, const uint_192 &rhs) noexcept {

--- a/uint_192_lib/src/uint_192.hpp
+++ b/uint_192_lib/src/uint_192.hpp
@@ -28,20 +28,18 @@ constexpr uint_192 operator<<(const uint_192 &number, const uint64_t shift) noex
     uint_192 result{};
     uint64_t carry{};
 
-    if (shift < UINT64_WIDTH) {
-        for (uint64_t current_position = 0; current_position < number.parts.size(); ++current_position) {
-            result.parts[current_position] += carry;
-            carry = number.parts[current_position] >> (UINT64_WIDTH - shift);
-            uint64_t shifted = number.parts[current_position] << shift;
-            result.parts[current_position] += shifted;
-        }
-
+    // Prevent UB when shifting by (UINT64_WIDTH - 0) => 64
+    if (shift == 0) {
+        result = number;
     } else {
         const uint64_t shift_adjust = shift % UINT64_WIDTH;
         const uint64_t shift_offset = shift / UINT64_WIDTH;
+        const uint64_t carry_shifting = UINT64_WIDTH - shift_adjust;
         for (uint64_t current_position = shift_offset; current_position < number.parts.size(); ++current_position) {
+            result.parts[current_position] += carry;
             const uint64_t shift_from_index = current_position - shift_offset;
-            result.parts[current_position] = number.parts[shift_from_index] << shift_adjust;
+            result.parts[current_position] += number.parts[shift_from_index] << shift_adjust;
+            carry = carry_shifting == 64 ? 0 : number.parts[shift_from_index] >> carry_shifting;
         }
     }
 

--- a/uint_192_lib/src/uint_192.hpp
+++ b/uint_192_lib/src/uint_192.hpp
@@ -46,11 +46,12 @@ constexpr uint_192 operator<<(const uint_192 &number, const uint64_t shift) noex
     return result;
 }
 
-constexpr bool operator==(const uint_192 &lhs, const uint_192 &rhs) { return lhs.parts == rhs.parts; }
+constexpr bool operator==(const uint_192 &lhs, const uint_192 &rhs) {
+    return lhs.parts == rhs.parts;
+}
 
 constexpr bool operator!=(const uint_192 &lhs, const uint_192 &rhs) {
     return lhs.parts != rhs.parts;
-    ;
 }
 
 constexpr bool operator<(const uint_192 &lhs, const uint_192 &rhs) {
@@ -63,12 +64,17 @@ constexpr bool operator<(const uint_192 &lhs, const uint_192 &rhs) {
     return false;
 }
 
-constexpr bool operator<=(const uint_192 &lhs, const uint_192 &rhs) { return lhs == rhs || lhs < rhs; }
+constexpr bool operator<=(const uint_192 &lhs, const uint_192 &rhs) {
+    return lhs == rhs || lhs < rhs;
+}
 
-constexpr bool operator>(const uint_192 &lhs, const uint_192 &rhs) { return !(lhs <= rhs); }
+constexpr bool operator>(const uint_192 &lhs, const uint_192 &rhs) {
+    return !(lhs <= rhs);
+}
 
-constexpr bool operator>=(const uint_192 &lhs, const uint_192 &rhs) { return !(lhs < rhs); }
-
+constexpr bool operator>=(const uint_192 &lhs, const uint_192 &rhs) {
+    return !(lhs < rhs);
+}
 
 } // namespace uint192_lib
 

--- a/uint_192_lib/src/uint_192.hpp
+++ b/uint_192_lib/src/uint_192.hpp
@@ -96,11 +96,11 @@ constexpr uint_192 operator*(const uint_192 &lhs, const uint_192 &rhs) {
     uint_192 result{};
 
     for (int lhs_iterator = 0; lhs_iterator < lhs.parts.size(); ++lhs_iterator) {
-        const uint32_t lhs_lower_bits = lhs.parts[lhs_iterator] & UINT32_MAX;
-        const uint32_t lhs_upper_bits = lhs.parts[lhs_iterator] >> UINT32_WIDTH;
+        const uint64_t lhs_lower_bits = lhs.parts[lhs_iterator] & UINT32_MAX;
+        const uint64_t lhs_upper_bits = lhs.parts[lhs_iterator] >> UINT32_WIDTH;
         for (int rhs_iterator = 0; rhs_iterator < rhs.parts.size(); ++rhs_iterator) {
-            const uint32_t rhs_lower_bits = rhs.parts[rhs_iterator] & UINT32_MAX;
-            const uint32_t rhs_upper_bits = rhs.parts[rhs_iterator] >> UINT32_WIDTH;
+            const uint64_t rhs_lower_bits = rhs.parts[rhs_iterator] & UINT32_MAX;
+            const uint64_t rhs_upper_bits = rhs.parts[rhs_iterator] >> UINT32_WIDTH;
 
             const uint_192 lower_lower = uint_192{lhs_lower_bits * rhs_lower_bits};
             const uint_192 lower_upper = uint_192{lhs_lower_bits * rhs_upper_bits};

--- a/uint_192_lib/src/uint_192.hpp
+++ b/uint_192_lib/src/uint_192.hpp
@@ -6,6 +6,7 @@
 
 #ifndef MY_UINT192_UINT_192_HPP
 #define MY_UINT192_UINT_192_HPP
+#include <bitset>
 
 namespace uint192_lib {
 struct uint_192 {
@@ -21,6 +22,14 @@ struct uint_192 {
         }
 
         return *this;
+    }
+
+    [[nodiscard]] std::string to_bin_string() const {
+        std::bitset<64> lower(this->parts[0]);
+        std::bitset<64> mid(this->parts[1]);
+        std::bitset<64> upper(this->parts[2]);
+
+        return upper.to_string() + mid.to_string() + lower.to_string();
     }
 };
 

--- a/uint_192_lib/tests/CMakeLists.txt
+++ b/uint_192_lib/tests/CMakeLists.txt
@@ -21,3 +21,4 @@ foreach (test_executable ${test_executables})
 
 endforeach ()
 
+add_subdirectory(fuzz_testing)

--- a/uint_192_lib/tests/fuzz_testing/CMakeLists.txt
+++ b/uint_192_lib/tests/fuzz_testing/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.26)
+
+
+# <----------------------- Register all catch2 tests ------------------------------------>
+find_package(GMP REQUIRED)
+
+file(GLOB test_executables LIST_DIRECTORIES false RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} fuzz_test_*.cpp)
+foreach (test_executable ${test_executables})
+    add_executable(fuzz_${test_executable} ${test_executable})
+    target_link_libraries(fuzz_${test_executable} PRIVATE Catch2::Catch2WithMain uint_192_lib GMP::STATIC)
+    catch_discover_tests(fuzz_${test_executable})
+
+endforeach ()

--- a/uint_192_lib/tests/fuzz_testing/catch2_uint192_generator.hpp
+++ b/uint_192_lib/tests/fuzz_testing/catch2_uint192_generator.hpp
@@ -1,0 +1,62 @@
+//
+// Created by jn98zk on 10.12.23.
+//
+
+#ifndef MY_UINT192_CATCH2_UINT192_GENERATOR_HPP
+#define MY_UINT192_CATCH2_UINT192_GENERATOR_HPP
+
+#include <catch2/benchmark/catch_benchmark.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <catch2/generators/catch_generators_all.hpp>
+#include <gmpxx.h>
+#include <iostream>
+#include <uint_192.hpp>
+
+struct Uint192_Generator : public Catch::Generators::IGenerator<uint192_lib::uint_192> {
+    std::minstd_rand m_rand{std::random_device{}()};
+    std::uniform_int_distribution<uint64_t> low_dist{0, UINT64_MAX};
+    std::uniform_int_distribution<uint64_t> mid_dist{0, UINT64_MAX};
+    std::uniform_int_distribution<uint64_t> high_dist{0, UINT64_MAX};
+    uint192_lib::uint_192 current_number{};
+
+    Uint192_Generator(uint64_t low_max, uint64_t min_max, uint64_t high_max) {
+        low_dist = std::uniform_int_distribution<uint64_t>{0, low_max};
+        mid_dist = std::uniform_int_distribution<uint64_t>{0, min_max};
+        high_dist = std::uniform_int_distribution<uint64_t>{0, high_max};
+        current_number = uint192_lib::uint_192{low_dist(m_rand), mid_dist(m_rand), high_dist(m_rand)};
+    }
+
+    uint192_lib::uint_192 const &get() const override {
+        return current_number;
+    }
+    bool next() override {
+        current_number = uint192_lib::uint_192{low_dist(m_rand), mid_dist(m_rand), high_dist(m_rand)};
+        return true;
+    }
+};
+
+Catch::Generators::GeneratorWrapper<uint192_lib::uint_192> randomUint192(uint64_t low_max, uint64_t min_max,
+                                                                         uint64_t high_max) {
+    return {new Uint192_Generator(low_max, min_max, high_max)};
+}
+
+mpz_class from_uint192(const uint192_lib::uint_192 &item) {
+    mpq_class lower(item.parts[0]);
+    mpq_class middle(item.parts[1]);
+    middle <<= UINT64_WIDTH;
+    mpq_class upper(item.parts[2]);
+    upper <<= (UINT64_WIDTH * 2);
+
+    return mpz_class(lower + middle + upper);
+}
+
+std::string strip_leading_zeros(const std::string &input) {
+    const auto index_of_significant_bit = input.rfind('1');
+    if (index_of_significant_bit == std::string::npos) {
+        return "";
+    }
+    return input.substr(index_of_significant_bit);
+}
+
+#endif // MY_UINT192_CATCH2_UINT192_GENERATOR_HPP

--- a/uint_192_lib/tests/fuzz_testing/fuzz_test_left_shifting.cpp
+++ b/uint_192_lib/tests/fuzz_testing/fuzz_test_left_shifting.cpp
@@ -1,0 +1,24 @@
+//
+// Created by jn98zk on 26.11.23.
+//
+
+#include "catch2_uint192_generator.hpp"
+
+TEST_CASE("Compare left shift implementation to GMP") {
+    const auto num_uint192 = GENERATE(take(120, randomUint192(UINT64_MAX, UINT64_MAX, 0)));
+    const auto shift_by = GENERATE(take(100, random<uint64_t>(0, 192)));
+    const auto num_GMP = from_uint192(num_uint192);
+
+    REQUIRE(strip_leading_zeros(num_GMP.get_str(2)) == strip_leading_zeros(num_uint192.to_bin_string()));
+
+    const auto num_uint192_result = num_uint192 << shift_by;
+    const auto GMP_result_bits = strip_leading_zeros(mpz_class(num_GMP << shift_by).get_str(2));
+
+    if (num_uint192_result == uint192_lib::uint_192{0, 0, 0}) {
+        REQUIRE(true);
+    }
+    const auto uint192_result_bits = strip_leading_zeros(num_uint192_result.to_bin_string());
+    bool isOk = GMP_result_bits.find(uint192_result_bits) != std::string::npos;
+
+    REQUIRE(isOk);
+}

--- a/uint_192_lib/tests/fuzz_testing/fuzz_test_multiplication.cpp
+++ b/uint_192_lib/tests/fuzz_testing/fuzz_test_multiplication.cpp
@@ -1,0 +1,27 @@
+//
+// Created by jn98zk on 26.11.23.
+//
+
+#include "catch2_uint192_generator.hpp"
+
+#include <uint_192.hpp>
+
+TEST_CASE("Compare multiplication to GMP") {
+    const auto lhs_uint192 = GENERATE(take(120, randomUint192(UINT64_MAX, UINT64_MAX, UINT64_MAX)));
+    const auto rhs_uint192 = GENERATE(take(120, randomUint192(UINT64_MAX, UINT64_MAX, UINT64_MAX)));
+    const auto lhs_GMP = from_uint192(lhs_uint192);
+    const auto rhs_GMP = from_uint192(rhs_uint192);
+
+    REQUIRE(strip_leading_zeros(lhs_GMP.get_str(2)) == strip_leading_zeros(lhs_uint192.to_bin_string()));
+
+    const auto result_uint192 = lhs_uint192 * rhs_uint192;
+    const auto result_GMP = mpz_class(lhs_GMP * rhs_GMP);
+
+    const auto GMP_result_bits = strip_leading_zeros(result_GMP.get_str(2));
+    if (GMP_result_bits.length() > 192) {
+        SKIP("RESULT is too big");
+    }
+    const auto uint192_result_bits = strip_leading_zeros(result_uint192.to_bin_string());
+
+    REQUIRE(GMP_result_bits == uint192_result_bits);
+}

--- a/uint_192_lib/tests/test_left_shifting.cpp
+++ b/uint_192_lib/tests/test_left_shifting.cpp
@@ -18,6 +18,13 @@ SCENARIO("Shifting left works") {
     GIVEN("A uint_192 of value {1,0,0}") {
         uint192_lib::uint_192 a{1};
 
+        THEN("Shifting it by 0 bits works") {
+            auto result = a << 0;
+            REQUIRE(result.parts[0] == 1);
+            REQUIRE(result.parts[1] == 0);
+            REQUIRE(result.parts[2] == 0);
+        }
+
         THEN("Shifting it by 1 bit works") {
             auto result = a << 1;
             REQUIRE(result.parts[0] == 2);
@@ -43,6 +50,20 @@ SCENARIO("Shifting left works") {
             auto result = a << UINT64_WIDTH;
             REQUIRE(result.parts[0] == 0);
             REQUIRE(result.parts[1] == 1);
+            REQUIRE(result.parts[2] == 0);
+        }
+
+        THEN("Shifting it by 65 bits works") {
+            auto result = a << 65;
+            REQUIRE(result.parts[0] == 0);
+            REQUIRE(result.parts[1] == 2);
+            REQUIRE(result.parts[2] == 0);
+        }
+
+        THEN("Shifting it by 96 bits works") {
+            auto result = a << 96;
+            REQUIRE(result.parts[0] == 0);
+            REQUIRE(result.parts[1] == 1UL << 32UL);
             REQUIRE(result.parts[2] == 0);
         }
 
@@ -288,6 +309,17 @@ SCENARIO("Shifting left works") {
             REQUIRE(result.parts[0] == 0);
             REQUIRE(result.parts[1] == 0);
             REQUIRE(result.parts[2] == 0);
+        }
+    }
+
+    GIVEN("A uint_192 of value {8589934590, 0 ,0}") {
+        uint192_lib::uint_192 a{8589934590, 0, 0};
+
+        THEN("Shifting it by 96 bit works correctly") {
+            auto result = a << 96;
+            REQUIRE(result.parts[0] == 0);
+            REQUIRE(result.parts[1] == 18446744065119617024UL);
+            REQUIRE(result.parts[2] == 1);
         }
     }
 }


### PR DESCRIPTION
1. Implements multiplication of 2 uint_192 
2. Fixes left shift missing bits that are supposed to be carried to the next position
3. Adds += operator 
4. Verifies correctness of the implementation by comparing the result to [GMP](https://gmplib.org/)